### PR TITLE
Update install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -152,15 +152,18 @@ cat <<EOF >"${PREFIX}/bin/okta-credential_process"
 #!/bin/bash
 roleARN="\$1"
 shift;
-env OKTA_AWS_ROLE_TO_ASSUME="\$roleARN" \
-    java -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.CredentialProcess
+env OKTA_AWS_ROLE_TO_ASSUME="\$roleARN" java \
+    -Djava.util.logging.config.file=${PREFIX}/logging.properties \
+    -classpath ${PREFIX}/okta-aws-cli.jar \
+    com.okta.tools.CredentialProcess
 EOF
 chmod +x "${PREFIX}/bin/okta-credential_process"
 
 # Create okta-listroles command
 cat <<EOF >"${PREFIX}/bin/okta-listroles"
 #!/bin/bash
-java -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.ListRoles
+java -Djava.util.logging.config.file=${PREFIX}/logging.properties \
+  -classpath ${PREFIX}/okta-aws-cli.jar com.okta.tools.ListRoles
 EOF
 chmod +x "${PREFIX}/bin/okta-listroles"
 


### PR DESCRIPTION
Adds logging.properties to all `/bin` scripts

Problem Statement
-----------------
logging.properties was not referenced with some of the `/bin` scripts provided.


Solution
--------
Added `java -D..` switch to include it in all `/bin` tools which require it.

