### PR TITLE
Update install.sh to use the new repo for okta-aws-cli-assume-role

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-repo_url="https://github.com/oktadeveloper/okta-aws-cli-assume-role"
+repo_url="https://github.com/oktadev/okta-aws-cli-assume-role"
 dotokta="${HOME}/.okta"
 
 printusage() {


### PR DESCRIPTION
Problem Statement
-----------------
Okta moved their repository that has the okta-aws-cli-assume-role. As a result, this script will fail to download the jar.


Solution
--------
Update to the new repo

